### PR TITLE
Use the same conditional install logic from unlit

### DIFF
--- a/ghc.mk
+++ b/ghc.mk
@@ -5,26 +5,21 @@ utils/hsc2hs_dist_PROGNAME         = hsc2hs
 utils/hsc2hs_dist-install_PROGNAME = hsc2hs
 
 utils/hsc2hs_dist_SHELL_WRAPPER = YES
-utils/hsc2hs_dist_INSTALL = NO
 utils/hsc2hs_dist_INSTALL_INPLACE = YES
 
 utils/hsc2hs_dist-install_SHELL_WRAPPER = YES
-utils/hsc2hs_dist-install_INSTALL = YES
 utils/hsc2hs_dist-install_INSTALL_INPLACE = NO
 
-$(eval $(call build-prog,utils/hsc2hs,dist,0))
-
-# When CrossCompiling, we want to ship the binary for the
-# host, not for the target.  As such we need to compile
-# with the Bootstrap compiler rather than with the in-tree
-# stage1 compiler, which would result in a binary that
-# won't run on the host.
-ifeq "$(CrossCompiling)" "YES"
-# compile with stage 0 (bootstrap compiler)
-$(eval $(call build-prog,utils/hsc2hs,dist-install,0))
+ifeq "$(Stage1Only)" "YES"
+utils/hsc2hs_dist_INSTALL         = YES
+utils/hsc2hs_dist-install_INSTALL = NO
 else
-$(eval $(call build-prog,utils/hsc2hs,dist-install,1))
+utils/hsc2hs_dist_INSTALL         = NO
+utils/hsc2hs_dist-install_INSTALL = YES
 endif
+
+$(eval $(call build-prog,utils/hsc2hs,dist,0))
+$(eval $(call build-prog,utils/hsc2hs,dist-install,1))
 
 # After build-prog above
 utils/hsc2hs_dist_MODULES += Paths_hsc2hs


### PR DESCRIPTION
This removes the make concurrency bug from the CrossCompilation fix, and uses the
same appraoch `utils/unlit` already uses.