### PR TITLE
Relative lookup of template-hsc.h

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -23,11 +23,6 @@ import System.Console.GetOpt
 -- XXX: Note this does not work
 --      on windows due to for
 --      symlinks. See Trac #14483.
-#if defined(IN_GHC_TREE)
-# if !MIN_VERSION_ghc_boot(8,3,0)
-#  error the impossible happened
-# endif
-#endif
 
 #if defined(mingw32_HOST_OS)
 import Foreign
@@ -45,10 +40,8 @@ import System.Directory         ( getCurrentDirectory )
 import Paths_hsc2hs as Main     ( getDataFileName )
 #endif
 #if defined(IN_GHC_TREE)
-import System.Directory         ( takeDirectory )
 import System.Environment       ( getExecutablePath )
-import System.FilePath          ( (</>) )
-
+import System.FilePath          ( takeDirectory, (</>) )
 #endif
 
 import Common

--- a/Main.hs
+++ b/Main.hs
@@ -34,7 +34,7 @@ import Foreign.C.String
 import System.Directory         ( doesFileExist, findExecutable )
 import System.Environment       ( getProgName, getArgs )
 import System.Exit              ( ExitCode(..), exitWith )
-import System.FilePath          ( normalise, splitFileName, splitExtension, (</>) )
+import System.FilePath          ( normalise, splitFileName, splitExtension )
 import System.IO
 
 #ifdef BUILD_NHC
@@ -44,6 +44,7 @@ import Paths_hsc2hs as Main     ( getDataFileName )
 #endif
 #if defined(IN_GHC_TREE)
 import GHC.BasePath             ( getBaseDir )
+import System.FilePath          ( (</>) )
 #endif
 
 import Common

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -56,9 +56,5 @@ Executable hsc2hs
                    filepath   >= 1   && < 1.5,
                    process    >= 1.1 && < 1.7
     if flag(in-ghc-tree)
-       if impl(ghc>=8.3)
-          cpp-options: -DIN_GHC_TREE
-          -- use @getBaseDir@ from ghc-boot to locate
-          -- the template-hsc.h file.
-          build-depends: ghc-boot >= 8.3 && < 8.5
+       cpp-options: -DIN_GHC_TREE
 

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -1,5 +1,5 @@
 Name: hsc2hs
-Version: 0.69.0
+Version: 0.68.3
 Copyright: 2000, Marcin Kowalczyk
 License: BSD3
 License-File: LICENSE
@@ -26,6 +26,11 @@ cabal-version: >=1.10
 extra-source-files: changelog.md
 tested-with: GHC==8.2.1, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
 
+flag in-ghc-tree
+  description: Are we in a GHC tree?
+  default: False
+  manual: True
+
 source-repository head
     Type: git
     Location: http://git.haskell.org/hsc2hs.git
@@ -50,8 +55,10 @@ Executable hsc2hs
                    directory  >= 1   && < 1.4,
                    filepath   >= 1   && < 1.5,
                    process    >= 1.1 && < 1.7
-    if impl(ghc)
-       -- use @getBaseDir@ from ghc-boot to locate
-       -- the template-hsc.h file.
-       build-depends: ghc-boot 
+    if flag(in-ghc-tree)
+       if impl(ghc>=8.3)
+          cpp-options: -DIN_GHC_TREE
+          -- use @getBaseDir@ from ghc-boot to locate
+          -- the template-hsc.h file.
+          build-depends: ghc-boot >= 8.3 && < 8.5
 

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -1,5 +1,5 @@
 Name: hsc2hs
-Version: 0.68.2
+Version: 0.69.0
 Copyright: 2000, Marcin Kowalczyk
 License: BSD3
 License-File: LICENSE
@@ -50,4 +50,8 @@ Executable hsc2hs
                    directory  >= 1   && < 1.4,
                    filepath   >= 1   && < 1.5,
                    process    >= 1.1 && < 1.7
+    if impl(ghc)
+       -- use @getBaseDir@ from ghc-boot to locate
+       -- the template-hsc.h file.
+       build-depends: ghc-boot 
 


### PR DESCRIPTION
As a last resort, try to find the `template-hsc.h` in `../lib` relative to the hsc2hs executable.