### PR TITLE
Drop Paths_hsc2hs module from ghc.mk

### DIFF
--- a/ghc.mk
+++ b/ghc.mk
@@ -27,7 +27,6 @@ $(eval $(call build-prog,utils/hsc2hs,dist-install,1))
 endif
 
 # After build-prog above
-utils/hsc2hs_dist_MODULES += Paths_hsc2hs
 utils/hsc2hs_dist-install_MODULES = $(utils/hsc2hs_dist_MODULES)
 
 utils/hsc2hs_template=$(INPLACE_TOPDIR)/template-hsc.h


### PR DESCRIPTION
In 598303cbffcd230635fbce28ce4105d177fdf76a the Paths_hsc2hs module was added to the other-modules.
As such, it should be dropped from the ghc.mk