### PR TITLE
spec: add more assembly examples surrently broken for GHC

### DIFF
--- a/Spec.hs
+++ b/Spec.hs
@@ -11,7 +11,23 @@ main = hspec $ do
           ,("x86_64 macos", "test/asm/x86_64-mac.s")
           ,("x86_64 mingw", "test/asm/x86_64-mingw32.s")
           ,("aarch64 ios",  "test/asm/aarch64-ios.s")
-          ,("aarch64 linux","test/asm/aarch64.s")]
+          ,("aarch64 linux","test/asm/aarch64.s")
+          ,("sparc linux",  "test/asm/sparc-linux.s")
+          ,("sparc64 linux","test/asm/sparc64-linux.s")
+          ,("mips linux",   "test/asm/mips-linux.s")
+          ,("mips64 linux", "test/asm/mips64-linux.s")
+          ,("powerpc linux","test/asm/powerpc-linux.s")
+          ,("powerpc64 linux","test/asm/powerpc64-linux.s")
+          ,("powerpc64le linux","test/asm/powerpc64le-linux.s")
+          ,("hppa linux",   "test/asm/hppa-linux.s")
+          ,("m68k linux",   "test/asm/m68k-linux.s")
+          ,("alpha linux",  "test/asm/alpha-linux.s")
+          ,("ia64 linux",   "test/asm/ia64-linux.s")
+          ,("nios2 linux",  "test/asm/nios2-linux.s")
+          ,("s390 linux",   "test/asm/s390-linux.s")
+          ,("s390x linux",  "test/asm/s390x-linux.s")
+          ,("sh4 linux",    "test/asm/sh4-linux.s")
+          ]
       $ \(d, f) ->do
       context d $ do
         x <- runIO $ parse f

--- a/test/asm/Makefile
+++ b/test/asm/Makefile
@@ -2,9 +2,24 @@ all:
 	clang -target arm-linux-gnueabihf -S -c tmp.c -o arm.s
 	clang -target aarch64-linux-gnueabihf -S -c tmp.c -o aarch64.s
 	clang -target arm64-apple-ios -S -c tmp.c -o aarch64-ios.s
-	clang -target armv7-apple-ios -S -c tmp.c -o arm-ios.s 
+	clang -target armv7-apple-ios -S -c tmp.c -o arm-ios.s
 	x86_64-w64-mingw32-gcc -S -c tmp.c -o x86_64-mingw32.s
 	clang -target i386-unknown-linux -S -c tmp.c -o x86-linux.s
 	clang -target x86_64-apple-macos -S -c tmp.c -o x86_64-mac.s
 	clang -target i386-unknown-linux -S -c tmp.c -o x86-linux.s
 	clang -target x86_64-unknown-linux -S -c tmp.c -o x86_64-linux.s
+	clang -target sparc-unknown-linux -S -c tmp.c -o sparc-linux.s
+	clang -target sparc64-unknown-linux -S -c tmp.c -o sparc64-linux.s
+	clang -target mips-unknown-linux -S -c tmp.c -o mips-linux.s
+	clang -target mips64-unknown-linux -S -c tmp.c -o mips64-linux.s
+	clang -target powerpc-unknown-linux -S -c tmp.c -o powerpc-linux.s
+	clang -target powerpc64-unknown-linux -S -c tmp.c -o powerpc64-linux.s
+	clang -target powerpc64le-unknown-linux -S -c tmp.c -o powerpc64le-linux.s
+	hppa-unknown-linux-gnu-gcc -S -c tmp.c -o hppa-linux.s
+	m68k-unknown-linux-gnu-gcc -S -c tmp.c -o m68k-linux.s
+	alpha-unknown-linux-gnu-gcc -S -c tmp.c -o alpha-linux.s
+	ia64-unknown-linux-gnu-gcc -S -c tmp.c -o ia64-linux.s
+	nios2-unknown-linux-gnu-gcc -S -c tmp.c -o nios2-linux.s
+	s390-unknown-linux-gnu-gcc -S -c tmp.c -o s390-linux.s
+	s390x-unknown-linux-gnu-gcc -S -c tmp.c -o s390x-linux.s
+	sh4-unknown-linux-gnu-gcc -S -c tmp.c -o sh4-linux.s

--- a/test/asm/alpha-linux.s
+++ b/test/asm/alpha-linux.s
@@ -1,0 +1,64 @@
+	.set noreorder
+	.set volatile
+	.set noat
+	.set nomacro
+	.arch ev4
+	.globl ___hsc2hs_BOM___
+	.section	.sdata,"aws",@progbits
+	.align 3
+	.type	___hsc2hs_BOM___, @object
+	.size	___hsc2hs_BOM___, 8
+___hsc2hs_BOM___:
+	.quad	4294967296
+	.globl x___hsc2hs_sign___
+	.section	.sbss,"aw"
+	.type	x___hsc2hs_sign___, @object
+	.size	x___hsc2hs_sign___, 8
+	.align 3
+x___hsc2hs_sign___:
+	.zero	8
+	.globl x
+	.section	.sdata
+	.align 3
+	.type	x, @object
+	.size	x, 8
+x:
+	.quad	1
+	.globl y___hsc2hs_sign___
+	.section	.sbss,"aw"
+	.type	y___hsc2hs_sign___, @object
+	.size	y___hsc2hs_sign___, 8
+	.align 3
+y___hsc2hs_sign___:
+	.zero	8
+	.globl y
+	.section	.sdata
+	.align 3
+	.type	y, @object
+	.size	y, 8
+y:
+	.quad	-1
+	.globl z___hsc2hs_sign___
+	.align 3
+	.type	z___hsc2hs_sign___, @object
+	.size	z___hsc2hs_sign___, 8
+z___hsc2hs_sign___:
+	.quad	1
+	.globl z
+	.align 3
+	.type	z, @object
+	.size	z, 8
+z:
+	.quad	-1
+	.globl t
+	.section	.rodata
+$LC0:
+	.string	"Hello World\" 12345"
+	.section	.sdata
+	.align 3
+	.type	t, @object
+	.size	t, 8
+t:
+	.quad	$LC0
+	.ident	"GCC: (Gentoo 7.2.0-r1 p1.1) 7.2.0"
+	.section	.note.GNU-stack,"",@progbits

--- a/test/asm/hppa-linux.s
+++ b/test/asm/hppa-linux.s
@@ -1,0 +1,67 @@
+	.LEVEL 1.1
+.globl ___hsc2hs_BOM___
+	.data
+	.align 8
+	.type	___hsc2hs_BOM___, @object
+	.size	___hsc2hs_BOM___, 8
+___hsc2hs_BOM___:
+	.word	1
+	.word	0
+.globl x___hsc2hs_sign___
+	.section	.bss
+	.align 8
+	.type	x___hsc2hs_sign___, @object
+	.size	x___hsc2hs_sign___, 8
+	.align 8
+x___hsc2hs_sign___:
+	.block 8
+.globl x
+	.data
+	.align 8
+	.type	x, @object
+	.size	x, 8
+x:
+	.word	0
+	.word	1
+.globl y___hsc2hs_sign___
+	.section	.bss
+	.align 8
+	.type	y___hsc2hs_sign___, @object
+	.size	y___hsc2hs_sign___, 8
+	.align 8
+y___hsc2hs_sign___:
+	.block 8
+.globl y
+	.data
+	.align 8
+	.type	y, @object
+	.size	y, 8
+y:
+	.word	-1
+	.word	-1
+.globl z___hsc2hs_sign___
+	.align 8
+	.type	z___hsc2hs_sign___, @object
+	.size	z___hsc2hs_sign___, 8
+z___hsc2hs_sign___:
+	.word	0
+	.word	1
+.globl z
+	.align 8
+	.type	z, @object
+	.size	z, 8
+z:
+	.word	-1
+	.word	-1
+.globl t
+	.section	.rodata
+	.align 4
+.LC0:
+	.stringz	"Hello World\" 12345"
+	.section	.data.rel.local,"aw",@progbits
+	.align 4
+	.type	t, @object
+	.size	t, 4
+t:
+	.word	.LC0
+	.ident	"GCC: (Gentoo 7.2.0-r1 p1.1) 7.2.0"

--- a/test/asm/ia64-linux.s
+++ b/test/asm/ia64-linux.s
@@ -1,0 +1,63 @@
+	.file	"tmp.c"
+	.pred.safe_across_calls p1-p5,p16-p63
+	.text
+	.global ___hsc2hs_BOM___#
+	.section	.sdata,"aws",@progbits
+	.align 8
+	.type	___hsc2hs_BOM___#, @object
+	.size	___hsc2hs_BOM___#, 8
+___hsc2hs_BOM___:
+	data8	4294967296
+	.global x___hsc2hs_sign___#
+	.section	.sbss,"aws",@nobits
+	.align 8
+	.type	x___hsc2hs_sign___#, @object
+	.size	x___hsc2hs_sign___#, 8
+x___hsc2hs_sign___:
+	.skip	8
+	.global x#
+	.section	.sdata
+	.align 8
+	.type	x#, @object
+	.size	x#, 8
+x:
+	data8	1
+	.global y___hsc2hs_sign___#
+	.section	.sbss
+	.align 8
+	.type	y___hsc2hs_sign___#, @object
+	.size	y___hsc2hs_sign___#, 8
+y___hsc2hs_sign___:
+	.skip	8
+	.global y#
+	.section	.sdata
+	.align 8
+	.type	y#, @object
+	.size	y#, 8
+y:
+	data8	-1
+	.global z___hsc2hs_sign___#
+	.align 8
+	.type	z___hsc2hs_sign___#, @object
+	.size	z___hsc2hs_sign___#, 8
+z___hsc2hs_sign___:
+	data8	1
+	.global z#
+	.align 8
+	.type	z#, @object
+	.size	z#, 8
+z:
+	data8	-1
+	.global t#
+	.section	.rodata
+	.align 8
+.LC0:
+	stringz	"Hello World\" 12345"
+	.section	.sdata
+	.align 8
+	.type	t#, @object
+	.size	t#, 8
+t:
+	data8	.LC0
+	.ident	"GCC: (Gentoo 7.3.0 p1.0) 7.3.0"
+	.section	.note.GNU-stack,"",@progbits

--- a/test/asm/m68k-linux.s
+++ b/test/asm/m68k-linux.s
@@ -1,0 +1,66 @@
+#NO_APP
+	.file	"tmp.c"
+	.globl	___hsc2hs_BOM___
+	.data
+	.align	2
+	.type	___hsc2hs_BOM___, @object
+	.size	___hsc2hs_BOM___, 8
+___hsc2hs_BOM___:
+	.long	1
+	.long	0
+	.globl	x___hsc2hs_sign___
+	.section	.bss
+	.align	2
+	.type	x___hsc2hs_sign___, @object
+	.size	x___hsc2hs_sign___, 8
+x___hsc2hs_sign___:
+	.zero	8
+	.globl	x
+	.data
+	.align	2
+	.type	x, @object
+	.size	x, 8
+x:
+	.long	0
+	.long	1
+	.globl	y___hsc2hs_sign___
+	.section	.bss
+	.align	2
+	.type	y___hsc2hs_sign___, @object
+	.size	y___hsc2hs_sign___, 8
+y___hsc2hs_sign___:
+	.zero	8
+	.globl	y
+	.data
+	.align	2
+	.type	y, @object
+	.size	y, 8
+y:
+	.long	-1
+	.long	-1
+	.globl	z___hsc2hs_sign___
+	.align	2
+	.type	z___hsc2hs_sign___, @object
+	.size	z___hsc2hs_sign___, 8
+z___hsc2hs_sign___:
+	.long	0
+	.long	1
+	.globl	z
+	.align	2
+	.type	z, @object
+	.size	z, 8
+z:
+	.long	-1
+	.long	-1
+	.globl	t
+	.section	.rodata
+.LC0:
+	.string	"Hello World\" 12345"
+	.section	.data.rel.local,"aw",@progbits
+	.align	2
+	.type	t, @object
+	.size	t, 4
+t:
+	.long	.LC0
+	.ident	"GCC: (Gentoo 7.2.0-r1 p1.1) 7.2.0"
+	.section	.note.GNU-stack,"",@progbits

--- a/test/asm/mips-linux.s
+++ b/test/asm/mips-linux.s
@@ -1,0 +1,78 @@
+	.text
+	.abicalls
+	.option	pic0
+	.section	.mdebug.abi32,"",@progbits
+	.nan	legacy
+	.file	"tmp.c"
+	.type	___hsc2hs_BOM___,@object # @___hsc2hs_BOM___
+	.data
+	.globl	___hsc2hs_BOM___
+	.p2align	3
+___hsc2hs_BOM___:
+	.8byte	4294967296              # 0x100000000
+	.size	___hsc2hs_BOM___, 8
+
+	.type	x___hsc2hs_sign___,@object # @x___hsc2hs_sign___
+	.bss
+	.globl	x___hsc2hs_sign___
+	.p2align	3
+x___hsc2hs_sign___:
+	.8byte	0                       # 0x0
+	.size	x___hsc2hs_sign___, 8
+
+	.type	x,@object               # @x
+	.data
+	.globl	x
+	.p2align	3
+x:
+	.8byte	1                       # 0x1
+	.size	x, 8
+
+	.type	y___hsc2hs_sign___,@object # @y___hsc2hs_sign___
+	.bss
+	.globl	y___hsc2hs_sign___
+	.p2align	3
+y___hsc2hs_sign___:
+	.8byte	0                       # 0x0
+	.size	y___hsc2hs_sign___, 8
+
+	.type	y,@object               # @y
+	.data
+	.globl	y
+	.p2align	3
+y:
+	.8byte	4294967295              # 0xffffffff
+	.size	y, 8
+
+	.type	z___hsc2hs_sign___,@object # @z___hsc2hs_sign___
+	.globl	z___hsc2hs_sign___
+	.p2align	3
+z___hsc2hs_sign___:
+	.8byte	1                       # 0x1
+	.size	z___hsc2hs_sign___, 8
+
+	.type	z,@object               # @z
+	.globl	z
+	.p2align	3
+z:
+	.8byte	-1                      # 0xffffffffffffffff
+	.size	z, 8
+
+	.type	$.str,@object           # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+$.str:
+	.asciz	"Hello World\" 12345"
+	.size	$.str, 19
+
+	.type	t,@object               # @t
+	.data
+	.globl	t
+	.p2align	2
+t:
+	.4byte	($.str)
+	.size	t, 4
+
+
+	.ident	"clang version 5.0.1 (tags/RELEASE_501/final)"
+	.section	".note.GNU-stack","",@progbits
+	.text

--- a/test/asm/mips64-linux.s
+++ b/test/asm/mips64-linux.s
@@ -1,0 +1,77 @@
+	.text
+	.abicalls
+	.section	.mdebug.abi64,"",@progbits
+	.nan	legacy
+	.file	"tmp.c"
+	.type	___hsc2hs_BOM___,@object
+	.data
+	.globl	___hsc2hs_BOM___
+	.p2align	3
+___hsc2hs_BOM___:
+	.8byte	4294967296
+	.size	___hsc2hs_BOM___, 8
+
+	.type	x___hsc2hs_sign___,@object
+	.bss
+	.globl	x___hsc2hs_sign___
+	.p2align	3
+x___hsc2hs_sign___:
+	.8byte	0
+	.size	x___hsc2hs_sign___, 8
+
+	.type	x,@object
+	.data
+	.globl	x
+	.p2align	3
+x:
+	.8byte	1
+	.size	x, 8
+
+	.type	y___hsc2hs_sign___,@object
+	.bss
+	.globl	y___hsc2hs_sign___
+	.p2align	3
+y___hsc2hs_sign___:
+	.8byte	0
+	.size	y___hsc2hs_sign___, 8
+
+	.type	y,@object
+	.data
+	.globl	y
+	.p2align	3
+y:
+	.8byte	-1
+	.size	y, 8
+
+	.type	z___hsc2hs_sign___,@object
+	.globl	z___hsc2hs_sign___
+	.p2align	3
+z___hsc2hs_sign___:
+	.8byte	1
+	.size	z___hsc2hs_sign___, 8
+
+	.type	z,@object
+	.globl	z
+	.p2align	3
+z:
+	.8byte	-1
+	.size	z, 8
+
+	.type	.L.str,@object
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"Hello World\" 12345"
+	.size	.L.str, 19
+
+	.type	t,@object
+	.data
+	.globl	t
+	.p2align	3
+t:
+	.8byte	.L.str
+	.size	t, 8
+
+
+	.ident	"clang version 5.0.1 (tags/RELEASE_501/final)"
+	.section	".note.GNU-stack","",@progbits
+	.text

--- a/test/asm/nios2-linux.s
+++ b/test/asm/nios2-linux.s
@@ -1,0 +1,65 @@
+	.file	"tmp.c"
+	.global	___hsc2hs_BOM___
+	.section	.sdata,"aws",@progbits
+	.align	2
+	.type	___hsc2hs_BOM___, @object
+	.size	___hsc2hs_BOM___, 8
+___hsc2hs_BOM___:
+	.long	0
+	.long	1
+	.global	x___hsc2hs_sign___
+	.section	.sbss,"aws",@nobits
+	.align	2
+	.type	x___hsc2hs_sign___, @object
+	.size	x___hsc2hs_sign___, 8
+x___hsc2hs_sign___:
+	.zero	8
+	.global	x
+	.section	.sdata
+	.align	2
+	.type	x, @object
+	.size	x, 8
+x:
+	.long	1
+	.long	0
+	.global	y___hsc2hs_sign___
+	.section	.sbss
+	.align	2
+	.type	y___hsc2hs_sign___, @object
+	.size	y___hsc2hs_sign___, 8
+y___hsc2hs_sign___:
+	.zero	8
+	.global	y
+	.section	.sdata
+	.align	2
+	.type	y, @object
+	.size	y, 8
+y:
+	.long	-1
+	.long	-1
+	.global	z___hsc2hs_sign___
+	.align	2
+	.type	z___hsc2hs_sign___, @object
+	.size	z___hsc2hs_sign___, 8
+z___hsc2hs_sign___:
+	.long	1
+	.long	0
+	.global	z
+	.align	2
+	.type	z, @object
+	.size	z, 8
+z:
+	.long	-1
+	.long	-1
+	.global	t
+	.section	.rodata
+	.align	2
+.LC0:
+	.string	"Hello World\" 12345"
+	.section	.sdata
+	.align	2
+	.type	t, @object
+	.size	t, 4
+t:
+	.long	.LC0
+	.ident	"GCC: (Gentoo 7.2.0-r1 p1.1) 7.2.0"

--- a/test/asm/powerpc-linux.s
+++ b/test/asm/powerpc-linux.s
@@ -1,0 +1,80 @@
+	.text
+	.file	"tmp.c"
+	.type	___hsc2hs_BOM___,@object # @___hsc2hs_BOM___
+	.data
+	.globl	___hsc2hs_BOM___
+	.p2align	3
+___hsc2hs_BOM___:
+	.long	1                       # 0x100000000
+	.long	0
+	.size	___hsc2hs_BOM___, 8
+
+	.type	x___hsc2hs_sign___,@object # @x___hsc2hs_sign___
+	.section	.bss,"aw",@nobits
+	.globl	x___hsc2hs_sign___
+	.p2align	3
+x___hsc2hs_sign___:
+	.long	0                       # 0x0
+	.long	0
+	.size	x___hsc2hs_sign___, 8
+
+	.type	x,@object               # @x
+	.data
+	.globl	x
+	.p2align	3
+x:
+	.long	0                       # 0x1
+	.long	1
+	.size	x, 8
+
+	.type	y___hsc2hs_sign___,@object # @y___hsc2hs_sign___
+	.section	.bss,"aw",@nobits
+	.globl	y___hsc2hs_sign___
+	.p2align	3
+y___hsc2hs_sign___:
+	.long	0                       # 0x0
+	.long	0
+	.size	y___hsc2hs_sign___, 8
+
+	.type	y,@object               # @y
+	.data
+	.globl	y
+	.p2align	3
+y:
+	.long	0                       # 0xffffffff
+	.long	4294967295
+	.size	y, 8
+
+	.type	z___hsc2hs_sign___,@object # @z___hsc2hs_sign___
+	.globl	z___hsc2hs_sign___
+	.p2align	3
+z___hsc2hs_sign___:
+	.long	0                       # 0x1
+	.long	1
+	.size	z___hsc2hs_sign___, 8
+
+	.type	z,@object               # @z
+	.globl	z
+	.p2align	3
+z:
+	.long	4294967295              # 0xffffffffffffffff
+	.long	4294967295
+	.size	z, 8
+
+	.type	.L.str,@object          # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"Hello World\" 12345"
+	.size	.L.str, 19
+
+	.type	t,@object               # @t
+	.data
+	.globl	t
+	.p2align	2
+t:
+	.long	.L.str
+	.size	t, 4
+
+
+	.ident	"clang version 5.0.1 (tags/RELEASE_501/final)"
+	.section	".note.GNU-stack","",@progbits

--- a/test/asm/powerpc64-linux.s
+++ b/test/asm/powerpc64-linux.s
@@ -1,0 +1,73 @@
+	.text
+	.file	"tmp.c"
+	.type	___hsc2hs_BOM___,@object # @___hsc2hs_BOM___
+	.data
+	.globl	___hsc2hs_BOM___
+	.p2align	3
+___hsc2hs_BOM___:
+	.quad	4294967296              # 0x100000000
+	.size	___hsc2hs_BOM___, 8
+
+	.type	x___hsc2hs_sign___,@object # @x___hsc2hs_sign___
+	.section	.bss,"aw",@nobits
+	.globl	x___hsc2hs_sign___
+	.p2align	3
+x___hsc2hs_sign___:
+	.quad	0                       # 0x0
+	.size	x___hsc2hs_sign___, 8
+
+	.type	x,@object               # @x
+	.data
+	.globl	x
+	.p2align	3
+x:
+	.quad	1                       # 0x1
+	.size	x, 8
+
+	.type	y___hsc2hs_sign___,@object # @y___hsc2hs_sign___
+	.section	.bss,"aw",@nobits
+	.globl	y___hsc2hs_sign___
+	.p2align	3
+y___hsc2hs_sign___:
+	.quad	0                       # 0x0
+	.size	y___hsc2hs_sign___, 8
+
+	.type	y,@object               # @y
+	.data
+	.globl	y
+	.p2align	3
+y:
+	.quad	-1                      # 0xffffffffffffffff
+	.size	y, 8
+
+	.type	z___hsc2hs_sign___,@object # @z___hsc2hs_sign___
+	.globl	z___hsc2hs_sign___
+	.p2align	3
+z___hsc2hs_sign___:
+	.quad	1                       # 0x1
+	.size	z___hsc2hs_sign___, 8
+
+	.type	z,@object               # @z
+	.globl	z
+	.p2align	3
+z:
+	.quad	-1                      # 0xffffffffffffffff
+	.size	z, 8
+
+	.type	.L.str,@object          # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"Hello World\" 12345"
+	.size	.L.str, 19
+
+	.type	t,@object               # @t
+	.data
+	.globl	t
+	.p2align	3
+t:
+	.quad	.L.str
+	.size	t, 8
+
+
+	.ident	"clang version 5.0.1 (tags/RELEASE_501/final)"
+	.section	".note.GNU-stack","",@progbits

--- a/test/asm/powerpc64le-linux.s
+++ b/test/asm/powerpc64le-linux.s
@@ -1,0 +1,74 @@
+	.text
+	.abiversion 2
+	.file	"tmp.c"
+	.type	___hsc2hs_BOM___,@object # @___hsc2hs_BOM___
+	.data
+	.globl	___hsc2hs_BOM___
+	.p2align	3
+___hsc2hs_BOM___:
+	.quad	4294967296              # 0x100000000
+	.size	___hsc2hs_BOM___, 8
+
+	.type	x___hsc2hs_sign___,@object # @x___hsc2hs_sign___
+	.section	.bss,"aw",@nobits
+	.globl	x___hsc2hs_sign___
+	.p2align	3
+x___hsc2hs_sign___:
+	.quad	0                       # 0x0
+	.size	x___hsc2hs_sign___, 8
+
+	.type	x,@object               # @x
+	.data
+	.globl	x
+	.p2align	3
+x:
+	.quad	1                       # 0x1
+	.size	x, 8
+
+	.type	y___hsc2hs_sign___,@object # @y___hsc2hs_sign___
+	.section	.bss,"aw",@nobits
+	.globl	y___hsc2hs_sign___
+	.p2align	3
+y___hsc2hs_sign___:
+	.quad	0                       # 0x0
+	.size	y___hsc2hs_sign___, 8
+
+	.type	y,@object               # @y
+	.data
+	.globl	y
+	.p2align	3
+y:
+	.quad	-1                      # 0xffffffffffffffff
+	.size	y, 8
+
+	.type	z___hsc2hs_sign___,@object # @z___hsc2hs_sign___
+	.globl	z___hsc2hs_sign___
+	.p2align	3
+z___hsc2hs_sign___:
+	.quad	1                       # 0x1
+	.size	z___hsc2hs_sign___, 8
+
+	.type	z,@object               # @z
+	.globl	z
+	.p2align	3
+z:
+	.quad	-1                      # 0xffffffffffffffff
+	.size	z, 8
+
+	.type	.L.str,@object          # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"Hello World\" 12345"
+	.size	.L.str, 19
+
+	.type	t,@object               # @t
+	.data
+	.globl	t
+	.p2align	3
+t:
+	.quad	.L.str
+	.size	t, 8
+
+
+	.ident	"clang version 5.0.1 (tags/RELEASE_501/final)"
+	.section	".note.GNU-stack","",@progbits

--- a/test/asm/s390-linux.s
+++ b/test/asm/s390-linux.s
@@ -1,0 +1,68 @@
+	.file	"tmp.c"
+	.machinemode esa
+	.machine "z900"
+.globl ___hsc2hs_BOM___
+.data
+	.align	8
+	.type	___hsc2hs_BOM___, @object
+	.size	___hsc2hs_BOM___, 8
+___hsc2hs_BOM___:
+	.long	1
+	.long	0
+.globl x___hsc2hs_sign___
+.bss
+	.align	8
+	.type	x___hsc2hs_sign___, @object
+	.size	x___hsc2hs_sign___, 8
+x___hsc2hs_sign___:
+	.zero	8
+.globl x
+.data
+	.align	8
+	.type	x, @object
+	.size	x, 8
+x:
+	.long	0
+	.long	1
+.globl y___hsc2hs_sign___
+.bss
+	.align	8
+	.type	y___hsc2hs_sign___, @object
+	.size	y___hsc2hs_sign___, 8
+y___hsc2hs_sign___:
+	.zero	8
+.globl y
+.data
+	.align	8
+	.type	y, @object
+	.size	y, 8
+y:
+	.long	-1
+	.long	-1
+.globl z___hsc2hs_sign___
+	.align	8
+	.type	z___hsc2hs_sign___, @object
+	.size	z___hsc2hs_sign___, 8
+z___hsc2hs_sign___:
+	.long	0
+	.long	1
+.globl z
+	.align	8
+	.type	z, @object
+	.size	z, 8
+z:
+	.long	-1
+	.long	-1
+.globl t
+	.section	.rodata
+	.align	2
+.LC0:
+	.string	"Hello World\" 12345"
+	.section	.data.rel.local,"aw",@progbits
+	.align	4
+	.type	t, @object
+	.size	t, 4
+t:
+	.long	.LC0
+	.ident	"GCC: (Gentoo 7.2.0-r1 p1.1) 7.2.0"
+	.section	.note.GNU-stack,"",@progbits

--- a/test/asm/s390x-linux.s
+++ b/test/asm/s390x-linux.s
@@ -1,0 +1,63 @@
+	.file	"tmp.c"
+	.machinemode zarch
+	.machine "z900"
+.globl ___hsc2hs_BOM___
+.data
+	.align	8
+	.type	___hsc2hs_BOM___, @object
+	.size	___hsc2hs_BOM___, 8
+___hsc2hs_BOM___:
+	.quad	4294967296
+.globl x___hsc2hs_sign___
+.bss
+	.align	8
+	.type	x___hsc2hs_sign___, @object
+	.size	x___hsc2hs_sign___, 8
+x___hsc2hs_sign___:
+	.zero	8
+.globl x
+.data
+	.align	8
+	.type	x, @object
+	.size	x, 8
+x:
+	.quad	1
+.globl y___hsc2hs_sign___
+.bss
+	.align	8
+	.type	y___hsc2hs_sign___, @object
+	.size	y___hsc2hs_sign___, 8
+y___hsc2hs_sign___:
+	.zero	8
+.globl y
+.data
+	.align	8
+	.type	y, @object
+	.size	y, 8
+y:
+	.quad	-1
+.globl z___hsc2hs_sign___
+	.align	8
+	.type	z___hsc2hs_sign___, @object
+	.size	z___hsc2hs_sign___, 8
+z___hsc2hs_sign___:
+	.quad	1
+.globl z
+	.align	8
+	.type	z, @object
+	.size	z, 8
+z:
+	.quad	-1
+.globl t
+	.section	.rodata
+	.align	2
+.LC0:
+	.string	"Hello World\" 12345"
+	.section	.data.rel.local,"aw",@progbits
+	.align	8
+	.type	t, @object
+	.size	t, 8
+t:
+	.quad	.LC0
+	.ident	"GCC: (Gentoo 7.2.0-r1 p1.1) 7.2.0"
+	.section	.note.GNU-stack,"",@progbits

--- a/test/asm/sh4-linux.s
+++ b/test/asm/sh4-linux.s
@@ -1,0 +1,68 @@
+	.file	"tmp.c"
+	.text
+	.little
+	.global	___hsc2hs_BOM___
+	.data
+	.align 2
+	.type	___hsc2hs_BOM___, @object
+	.size	___hsc2hs_BOM___, 8
+___hsc2hs_BOM___:
+	.long	0
+	.long	1
+	.global	x___hsc2hs_sign___
+	.section	.bss
+	.align 2
+	.type	x___hsc2hs_sign___, @object
+	.size	x___hsc2hs_sign___, 8
+x___hsc2hs_sign___:
+	.zero	8
+	.global	x
+	.data
+	.align 2
+	.type	x, @object
+	.size	x, 8
+x:
+	.long	1
+	.long	0
+	.global	y___hsc2hs_sign___
+	.section	.bss
+	.align 2
+	.type	y___hsc2hs_sign___, @object
+	.size	y___hsc2hs_sign___, 8
+y___hsc2hs_sign___:
+	.zero	8
+	.global	y
+	.data
+	.align 2
+	.type	y, @object
+	.size	y, 8
+y:
+	.long	-1
+	.long	-1
+	.global	z___hsc2hs_sign___
+	.align 2
+	.type	z___hsc2hs_sign___, @object
+	.size	z___hsc2hs_sign___, 8
+z___hsc2hs_sign___:
+	.long	1
+	.long	0
+	.global	z
+	.align 2
+	.type	z, @object
+	.size	z, 8
+z:
+	.long	-1
+	.long	-1
+	.global	t
+	.section	.rodata
+	.align 2
+.LC0:
+	.string	"Hello World\" 12345"
+	.section	.data.rel.local,"aw",@progbits
+	.align 2
+	.type	t, @object
+	.size	t, 4
+t:
+	.long	.LC0
+	.ident	"GCC: (Gentoo 7.2.0-r1 p1.1) 7.2.0"
+	.section	.note.GNU-stack,"",@progbits

--- a/test/asm/sparc-linux.s
+++ b/test/asm/sparc-linux.s
@@ -1,0 +1,80 @@
+	.text
+	.file	"tmp.c"
+	.type	___hsc2hs_BOM___,@object
+	.data
+	.globl	___hsc2hs_BOM___
+	.p2align	3
+___hsc2hs_BOM___:
+	.word	1
+	.word	0
+	.size	___hsc2hs_BOM___, 8
+
+	.type	x___hsc2hs_sign___,@object
+	.section	.bss,#alloc,#write
+	.globl	x___hsc2hs_sign___
+	.p2align	3
+x___hsc2hs_sign___:
+	.word	0
+	.word	0
+	.size	x___hsc2hs_sign___, 8
+
+	.type	x,@object
+	.data
+	.globl	x
+	.p2align	3
+x:
+	.word	0
+	.word	1
+	.size	x, 8
+
+	.type	y___hsc2hs_sign___,@object
+	.section	.bss,#alloc,#write
+	.globl	y___hsc2hs_sign___
+	.p2align	3
+y___hsc2hs_sign___:
+	.word	0
+	.word	0
+	.size	y___hsc2hs_sign___, 8
+
+	.type	y,@object
+	.data
+	.globl	y
+	.p2align	3
+y:
+	.word	0
+	.word	4294967295
+	.size	y, 8
+
+	.type	z___hsc2hs_sign___,@object
+	.globl	z___hsc2hs_sign___
+	.p2align	3
+z___hsc2hs_sign___:
+	.word	0
+	.word	1
+	.size	z___hsc2hs_sign___, 8
+
+	.type	z,@object
+	.globl	z
+	.p2align	3
+z:
+	.word	4294967295
+	.word	4294967295
+	.size	z, 8
+
+	.type	.L.str,@object
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"Hello World\" 12345"
+	.size	.L.str, 19
+
+	.type	t,@object
+	.data
+	.globl	t
+	.p2align	2
+t:
+	.word	.L.str
+	.size	t, 4
+
+
+	.ident	"clang version 5.0.1 (tags/RELEASE_501/final)"
+	.section	".note.GNU-stack"

--- a/test/asm/sparc64-linux.s
+++ b/test/asm/sparc64-linux.s
@@ -1,0 +1,73 @@
+	.text
+	.file	"tmp.c"
+	.type	___hsc2hs_BOM___,@object
+	.data
+	.globl	___hsc2hs_BOM___
+	.p2align	3
+___hsc2hs_BOM___:
+	.xword	4294967296
+	.size	___hsc2hs_BOM___, 8
+
+	.type	x___hsc2hs_sign___,@object
+	.section	.bss,#alloc,#write
+	.globl	x___hsc2hs_sign___
+	.p2align	3
+x___hsc2hs_sign___:
+	.xword	0
+	.size	x___hsc2hs_sign___, 8
+
+	.type	x,@object
+	.data
+	.globl	x
+	.p2align	3
+x:
+	.xword	1
+	.size	x, 8
+
+	.type	y___hsc2hs_sign___,@object
+	.section	.bss,#alloc,#write
+	.globl	y___hsc2hs_sign___
+	.p2align	3
+y___hsc2hs_sign___:
+	.xword	0
+	.size	y___hsc2hs_sign___, 8
+
+	.type	y,@object
+	.data
+	.globl	y
+	.p2align	3
+y:
+	.xword	-1
+	.size	y, 8
+
+	.type	z___hsc2hs_sign___,@object
+	.globl	z___hsc2hs_sign___
+	.p2align	3
+z___hsc2hs_sign___:
+	.xword	1
+	.size	z___hsc2hs_sign___, 8
+
+	.type	z,@object
+	.globl	z
+	.p2align	3
+z:
+	.xword	-1
+	.size	z, 8
+
+	.type	.L.str,@object
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"Hello World\" 12345"
+	.size	.L.str, 19
+
+	.type	t,@object
+	.data
+	.globl	t
+	.p2align	3
+t:
+	.xword	.L.str
+	.size	t, 8
+
+
+	.ident	"clang version 5.0.1 (tags/RELEASE_501/final)"
+	.section	".note.GNU-stack"


### PR DESCRIPTION
These are tests to illustrate GHC cross-compilation failures:
    https://ghc.haskell.org/trac/ghc/ticket/14889
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>