### PR TITLE
Remove an unused match

### DIFF
--- a/HSCParser.hs
+++ b/HSCParser.hs
@@ -167,7 +167,7 @@ text = do
         '\"':_        -> do anyChar_; hsString '\"'; text
         -- See Note [Single Quotes]
         '\'':'\\':_ -> do anyChar_; hsString '\''; text -- Case 1
-        '\'':d:'\'':_ -> do any3Chars_; text -- Case 2
+        '\'':_:'\'':_ -> do any3Chars_; text -- Case 2
         '\'':d:_ | isSpace d -> do -- Case 3
           any2Chars_
           manySatisfy_ (\c' -> isSpace c')

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -61,6 +61,8 @@ Executable hsc2hs
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.5,
                    process    >= 1.1.0 && < 1.7
+
+    ghc-options:   -Wall
     if flag(in-ghc-tree)
        cpp-options: -DIN_GHC_TREE
 


### PR DESCRIPTION
This fixes a warning, so that we can validate with `-Werror` again.