### PR TITLE
hsc2hs: Make removeFile more reliable on Windows.

### DIFF
--- a/Common.hs
+++ b/Common.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE CPP #-}
 module Common where
 
-#if MIN_VERSION_process (1,5,0)
-import Control.Concurrent       ( threadDelay )
-#endif
 import qualified Control.Exception as Exception
 import Control.Monad            ( when )
 import System.IO
-#if MIN_VERSION_process (1,5,0)
+#if defined(mingw32_HOST_OS)
+import Control.Concurrent       ( threadDelay )
 import System.IO.Error          ( isPermissionError )
 #endif
 import System.Process           ( rawSystem, createProcess, waitForProcess

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## 0.68.6
+
+ - Temporary file removals on Windows are not a bit more reliable and should
+   throw less access denied errors.  See #25 and
+   ([#9775](https://gitlab.haskell.org/ghc/ghc/issues/9775))
+
 ## 0.68.5
 
  - Support response files regardless of which GHC `hsc2hs` was compiled

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -60,7 +60,10 @@ Executable hsc2hs
                    containers >= 0.4.0 && < 0.7,
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.5,
-                   process    >= 1.4.3 && < 1.7
+                   process    >= 1.1.0 && < 1.7
+
+    if os(windows)
+      Build-Depends: process  >= 1.5.0 && < 1.7
 
     ghc-options:   -Wall
     if flag(in-ghc-tree)

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -60,7 +60,7 @@ Executable hsc2hs
                    containers >= 0.4.0 && < 0.7,
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.5,
-                   process    >= 1.1.0 && < 1.7
+                   process    >= 1.4.3 && < 1.7
 
     ghc-options:   -Wall
     if flag(in-ghc-tree)


### PR DESCRIPTION
This makes errors such as those in https://gitlab.haskell.org/ghc/ghc/issues/9775#note_203453 a lot rarer.

It does this by using two things:

1) It uses a process API that on Windows causes `waitForProcess` to wait for all child processes to complete.  This is required because the tools that `hsc2hs` use call `exec` which does not behave as you would expect on Windows.  The parent will return before the child finishes and so you have a race condition. On other OSes this flag has no effect.

2) It implements a retry queue which tries to delete a file 6 times if it's a permission error that prevented you from deleting it.  This because the temp file could be locked by an AV for scanning. The total wait time is ~3secs.