### PR TITLE
Fix order of inclusions

### DIFF
--- a/UtilsCodegen.hs
+++ b/UtilsCodegen.hs
@@ -28,13 +28,16 @@ withUtilsObject config outDir outBase f = do
 
     possiblyRemove cUtilsName $ do
         writeBinaryFile cUtilsName $ unlines $
-            ["#include <stddef.h>",
+             -- These header will cause a mismatch with any mingw-w64 header by
+             -- including system headers before user headers in the hsc file.
+             -- We *MUST* include user headers *BEFORE* automatic ones.  */
+            [outTemplateHeaderCProg (cTemplate config),
+             "",
+             "#include <stddef.h>",
              "#include <string.h>",
              "#include <stdio.h>",
              "#include <stdarg.h>",
              "#include <ctype.h>",
-             "",
-             outTemplateHeaderCProg (cTemplate config),
              "",
              "int hsc_printf(const char *format, ...) {",
              "    int r;",

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 ## 0.68.6
 
  - Supports generation of response files to avoid system filepath limits (#22, #23).
- 
+
  - Temporary file removals on Windows are not a bit more reliable and should
    throw less access denied errors.  See #25 and
    ([#9775](https://gitlab.haskell.org/ghc/ghc/issues/9775))
@@ -14,7 +14,7 @@
 
  - Include template file as first header in hsc2hs generated C file.
 
- - On Windows define __USE_MINGW_ANSI_STDIO to 1 instead of 0 when not already
+ - On Windows define `__USE_MINGW_ANSI_STDIO` to 1 instead of 0 when not already
    defined in standard template header.  This is a more modern default.
 
 ## 0.68.5

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,13 @@
 
  - Support `MonadFail` / base-4.13
 
+ - Support GHC 8.10.1
+
+ - Include template file as first header in hsc2hs generated C file.
+
+ - On Windows define __USE_MINGW_ANSI_STDIO to 1 instead of 0 when not already
+   defined in standard template header.  This is a more modern default.
+
 ## 0.68.5
 
  - Support response files regardless of which GHC `hsc2hs` was compiled

--- a/template-hsc.h
+++ b/template-hsc.h
@@ -1,3 +1,10 @@
+/* This header will cause a mismatch with any mingw-w64 header by including a
+   system header and then getting included before user headers in the hsc file.
+   So let's define the default to be mingw-w64 C99 so we have any hope of
+   getting GHC to compile with GCC 9+.  */
+#if defined(_WIN32) && !defined(__USE_MINGW_ANSI_STDIO)
+#  define __USE_MINGW_ANSI_STDIO 1
+#endif
 
 /* We need stddef to be able to use size_t. Hopefully this won't cause
    any problems along the lines of ghc trac #2897. */


### PR DESCRIPTION
hsc2hs is doing something shady, essentially it's generated headers etc are included *before* user headers. This changes the behavior of the includes.

On Windows it means we've always gotten deprecation warning but ignored it since `-Werror` dit not catch it before. However GCC9 is much better at this and so now we can't bootstrap GHC with GCC9 on Windows since this fails `-Werror`.

This patch changed it to put the template header first (certainly before first `_mingw.h` is included. We also define `__USE_MINGW_ANSI_STDIO` , this makes fixing of the other errors in GHC codebase possible.