### PR TITLE
hsc2hs: fix non-deterministic failures for response file handlings

### DIFF
--- a/Common.hs
+++ b/Common.hs
@@ -14,6 +14,7 @@ import System.Process           ( createProcess, waitForProcess
                                 , proc, CreateProcess(..), StdStream(..) )
 import System.Exit              ( ExitCode(..), exitWith )
 import System.Directory         ( removeFile )
+import System.FilePath          ( (</>) )
 
 die :: String -> IO a
 die s = hPutStr stderr s >> exitWith (ExitFailure 1)
@@ -27,11 +28,21 @@ default_compiler = "gcc"
 writeBinaryFile :: FilePath -> String -> IO ()
 writeBinaryFile fp str = withBinaryFile fp WriteMode $ \h -> hPutStr h str
 
-rawSystemL :: FilePath -> String -> Bool -> FilePath -> [String] -> IO ()
-rawSystemL outDir action flg prog args = withResponseFile outDir "c2hscall.rsp" args $ \rspFile -> do
+rawSystemL :: FilePath -> FilePath -> String -> Bool -> FilePath -> [String] -> IO ()
+rawSystemL outDir outBase action flg prog args = withResponseFile outDir outBase args $ \rspFile -> do
   let cmdLine = prog++" "++unwords args
   when flg $ hPutStrLn stderr ("Executing: " ++ cmdLine)
-  (_,_,_,ph) <- createProcess (proc prog ['@':rspFile])
+  (_,_,_,ph) <- createProcess
+  -- Because of the response files being written and removed after the process
+  -- terminates we now need to use process jobs here to correctly wait for all
+  -- child processes to terminate.  Not doing so would causes a race condition
+  -- between the last child dieing and not holding a lock on the response file
+  -- and the response file getting deleted.
+#if MIN_VERSION_process (1,5,0)
+    (proc prog ['@':rspFile]){ use_process_jobs = True }
+#else
+    (proc prog ['@':rspFile])
+#endif
   exitStatus <- waitForProcess ph
   case exitStatus of
     ExitFailure exitCode -> die $ action ++ " failed "
@@ -40,8 +51,8 @@ rawSystemL outDir action flg prog args = withResponseFile outDir "c2hscall.rsp" 
     _                    -> return ()
 
 
-rawSystemWithStdOutL :: FilePath -> String -> Bool -> FilePath -> [String] -> FilePath -> IO ()
-rawSystemWithStdOutL outDir action flg prog args outFile = withResponseFile outDir "c2hscall.rsp" args $ \rspFile -> do
+rawSystemWithStdOutL :: FilePath -> FilePath -> String -> Bool -> FilePath -> [String] -> FilePath -> IO ()
+rawSystemWithStdOutL outDir outBase action flg prog args outFile = withResponseFile outDir outBase args $ \rspFile -> do
   let cmdLine = prog++" "++unwords args++" >"++outFile
   when flg (hPutStrLn stderr ("Executing: " ++ cmdLine))
   hOut <- openFile outFile WriteMode
@@ -110,15 +121,15 @@ onlyOne what = die ("Only one "++what++" may be specified\n")
 
 -- response file handling borrowed from cabal's at Distribution.Simple.Program.ResponseFile
 
-withTempFile :: FilePath    -- ^ Temp dir to create the file in
-             -> String   -- ^ File name template. See 'openTempFile'.
+withTempFile :: FilePath -- ^ Temp dir to create the file in
+             -> FilePath -- ^ Name of the hsc file being processed
              -> (FilePath -> Handle -> IO a) -> IO a
-withTempFile tmpDir template action =
+withTempFile tmpDir outBase action =
   Exception.bracket
-    (openTempFile tmpDir template)
-    (\(name, handle) -> do hClose handle
-                           removeFile $ name)
-    (uncurry action)
+    (openFile rspFile ReadWriteMode)
+    (\handle -> finallyRemove rspFile $ hClose handle)
+    (action rspFile)
+    where rspFile = tmpDir </> (outBase ++"_hsc_make.rsp")
 
 withResponseFile ::
      FilePath           -- ^ Working directory to create response file in.
@@ -126,8 +137,8 @@ withResponseFile ::
   -> [String]           -- ^ Arguments to put into response file.
   -> (FilePath -> IO a)
   -> IO a
-withResponseFile workDir fileNameTemplate arguments f =
-  withTempFile workDir fileNameTemplate $ \responseFileName hf -> do
+withResponseFile workDir outBase arguments f =
+  withTempFile workDir outBase $ \responseFileName hf -> do
     let responseContents = unlines $ map escapeResponseFileArg arguments
     hPutStr hf responseContents
     hClose hf

--- a/DirectCodegen.hs
+++ b/DirectCodegen.hs
@@ -73,7 +73,8 @@ outputDirect config outName outDir outBase name toks = do
 
     when (cNoCompile config) $ exitWith ExitSuccess
 
-    rawSystemL outDir ("compiling " ++ cProgName) beVerbose (cCompiler config)
+    rawSystemL outDir outBase ("compiling " ++ cProgName) beVerbose
+        (cCompiler config)
         (  ["-c"]
         ++ [cProgName]
         ++ ["-o", oProgName]
@@ -82,14 +83,15 @@ outputDirect config outName outDir outBase name toks = do
     possiblyRemove cProgName $
         withUtilsObject config outDir outBase $ \oUtilsName -> do
 
-      rawSystemL outDir ("linking " ++ oProgName) beVerbose (cLinker config)
+      rawSystemL outDir outBase ("linking " ++ oProgName) beVerbose
+        (cLinker config)
         (  [oProgName, oUtilsName]
         ++ ["-o", progName]
         ++ [f | LinkFlag f <- flags]
         )
       possiblyRemove oProgName $ do
 
-        rawSystemWithStdOutL outDir ("running " ++ execProgName) beVerbose execProgName [] outName
+        rawSystemWithStdOutL outDir outBase ("running " ++ execProgName) beVerbose execProgName [] outName
         possiblyRemove progName $ do
 
           when needsH $ writeBinaryFile outHName $

--- a/UtilsCodegen.hs
+++ b/UtilsCodegen.hs
@@ -79,7 +79,7 @@ withUtilsObject config outDir outBase f = do
 
         possiblyRemove oUtilsName $ do
            unless (cNoCompile config) $
-               rawSystemL outDir ("compiling " ++ cUtilsName)
+               rawSystemL outDir outBase ("compiling " ++ cUtilsName)
                           beVerbose
                           (cCompiler config)
                           (["-c", cUtilsName, "-o", oUtilsName] ++


### PR DESCRIPTION
#23 introduced a couple of non-deterministic failures in hsc2hs on Windows.

1. `removeFile` should never be used in combination with `createProcess` on temporary files on Windows. Since tools such as AVs can have a lock on the file the removal may fail. Instead `finallyRemove` should always be used.
2. It created a race condition in `rawSystemL` by creating a dependency on an output file (the response file) and calling `createProcess` without using process jobs. Since it's invoking unix tools that use `spawn` it NEEDS to use process jobs to wait for when it's safe to delete the response file.
3. `openTempFile` is non-deterministic on Windows on anything but GHC 8.10. As such hsc2hs normally uses deterministic filenames for temporary files. By using `openTempFile` you get random failures such as

```
hsc2hs.exe: libraries/ghc-heap/dist-boot/build/GHC/Exts/Heap/\c2h4782.rsp: DeleteFile "\\\\?\\E:\\ghc-dev\\msys64\\home\\Tamar\\ghc\\libraries\\ghc-heap\\dist-boot\\build\\GHC\\Exts\\Heap\\c2h4782.rsp": does not exist (The system cannot find the file specified.)
```

Because the `rename` of the tempfile to the template is not atomic untill GHC 8.10.
