### PR TITLE
Fix nested temp calls with same base name

### DIFF
--- a/Common.hs
+++ b/Common.hs
@@ -171,7 +171,7 @@ withResponseFile ::
   -> (FilePath -> IO a)
   -> IO a
 withResponseFile workDir outBase arguments f =
-  withTempFile workDir outBase "c2hscall.rsp" (length arguments) $ \responseFileName hf -> do
+  withTempFile workDir outBase "hsc2hscall.rsp" (length arguments) $ \responseFileName hf -> do
     let responseContents = unlines $ map escapeResponseFileArg arguments
     hPutStr hf responseContents
     hClose hf

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 0.68.7
+
+ - Fix race condition when using response files (#30)
+
 ## 0.68.6
 
  - Supports generation of response files to avoid system filepath limits (#22, #23).


### PR DESCRIPTION
My fix in #29 assumed that response files were created in sequence. it turns out that the call to `withUtilsObject` also created one, but it was nested inside the call of another one creating a response file.

This would have been OK if the call in `withUtilsObject` gave the temp file function a different `basename` but it gave the same one.  This created a race condition in that two completely independent I/O write requests are issued almost simultaneously to the OS. If the OS handles them in the order they were given than it all works out. if the OS handles them out of order, or handles them in batch it would fail.

A simple fix would be to change the `base` in `withUtilsObject` but I felt this was a bit fragile. So instead I added a check to insure that we only write to non-existent response files, so that this case generates and error in hsc2hs instead of a nasty race condition.

The second thing I did was introduced a semi-random number to disambiguate between calls with the same base.  It's not fully random as `hsc2hs` doesn't have a dependency on `random` and `random` isn't a boot package.  But it's random enough to make sure this case almost never happens and if it does you would get a reasonable error now.

Fixes https://gitlab.haskell.org/ghc/ghc/issues/17108 