### PR TITLE
Use cc rather than gcc as default compiler

### DIFF
--- a/Common.hs
+++ b/Common.hs
@@ -21,7 +21,7 @@ die :: String -> IO a
 die s = hPutStr stderr s >> exitWith (ExitFailure 1)
 
 default_compiler :: String
-default_compiler = "gcc"
+default_compiler = "cc"
 
 ------------------------------------------------------------------------
 -- Write the output files.


### PR DESCRIPTION
This is the morally right thing to do and fixes FreeBSD,
which ships only with clang.