### PR TITLE
Bump base upper bound to 4.16

### DIFF
--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -60,7 +60,7 @@ Executable hsc2hs
 
     Other-Extensions: CPP, NoMonomorphismRestriction
 
-    Build-Depends: base       >= 4.3.0 && < 4.16,
+    Build-Depends: base       >= 4.3.0 && < 4.17,
                    containers >= 0.4.0 && < 0.7,
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.5,


### PR DESCRIPTION
Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4082#note_300462