### PR TITLE
Avoid Data.List.{head,tail}

### DIFF
--- a/src/ATTParser.hs
+++ b/src/ATTParser.hs
@@ -99,7 +99,11 @@ preprocess ('\t':attr) = let (h, t) = break isSpace attr
                          -- ia64
                          ("stringz":x:_)            -> [mkAscii $ read x ++ "\0"]
                          _                          -> []
-  where w = head . words
+  where
+    w x = case words x of
+      []     -> error $ "preprocess: expected some non-space characters, "
+                     ++ "but got spaces only in '" ++ x ++ "'"
+      hd : _ -> hd
 preprocess ('.':'z':'e':'r':'o':'f':'i':'l':'l':' ':x) = case words' (==',') x of
       (_seg:_sect:sym:size:_) | size == "4" -> [Ident sym, mkLong 0]
                               | size == "8" -> [Ident sym, mkQuad 0]


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings.

This patch eliminates the only usage of `head` in `hsc2hs`.