### PR TITLE
Bump bounds to accommodate base-4.18

### DIFF
--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -62,7 +62,7 @@ Executable hsc2hs
 
     Other-Extensions: CPP, NoMonomorphismRestriction
 
-    Build-Depends: base       >= 4.3.0 && < 4.18,
+    Build-Depends: base       >= 4.3.0 && < 4.19,
                    containers >= 0.4.0 && < 0.7,
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.5,


### PR DESCRIPTION
In service of [GHC 9.6.1](https://gitlab.haskell.org/ghc/ghc/-/issues/22562).