### PR TITLE
Fix pointer type detection in cross mode (again)

### DIFF
--- a/src/CrossCodegen.hs
+++ b/src/CrossCodegen.hs
@@ -589,8 +589,8 @@ runCompileIsPointerTest (ZCursor s above below) ty = do
                (concatMap outHeaderCProg' above) ++
                outHeaderCProg' s ++
                -- the test
-               "void _hsc2hs_test(" ++ ty ++ " val) {\n" ++
-               "  memset(val, 0, 0);\n" ++
+               "void *_hsc2hs_test(" ++ ty ++ " val) {\n" ++
+               "  return val;\n" ++
                "}\n" ++
                (concatMap outHeaderCProg' below)
     runCompileTest test


### PR DESCRIPTION
This is a fix for https://gitlab.haskell.org/ghc/ghc/-/issues/22981.

I've checked that GHC for wasm32-wasi builds successfully on AArch64 Linux with this patch.
