### PR TITLE
Bump base bound to <4.20

### DIFF
--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -78,7 +78,7 @@ Executable hsc2hs
 
     Other-Extensions: CPP, NoMonomorphismRestriction
 
-    Build-Depends: base       >= 4.3.0 && < 4.19,
+    Build-Depends: base       >= 4.3.0 && < 4.20,
                    containers >= 0.4.0 && < 0.7,
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.5,


### PR DESCRIPTION
For GHC 9.8.