### PR TITLE
Allow building with `filepath-1.5.*`

### DIFF
--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -83,7 +83,7 @@ Executable hsc2hs
     Build-Depends: base       >= 4.3.0 && < 4.20,
                    containers >= 0.4.0 && < 0.8,
                    directory  >= 1.1.0 && < 1.4,
-                   filepath   >= 1.2.0 && < 1.5,
+                   filepath   >= 1.2.0 && < 1.6,
                    process    >= 1.1.0 && < 1.7
 
     if os(windows)


### PR DESCRIPTION
`filepath-1.5.0.0` removes the `OsString` modules. This does not affect `hsc2hs`'s use of `filepath`, and `hsc2hs`'s test suite passes without issues when building with `filepath-1.5.0.0`.

Fixes #86.