### PR TITLE
Support ghc-9.12

### DIFF
--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -82,7 +82,7 @@ Executable hsc2hs
 
     Other-Extensions: CPP, NoMonomorphismRestriction
 
-    Build-Depends: base       >= 4.3.0 && < 4.21,
+    Build-Depends: base       >= 4.3.0 && < 4.22,
                    containers >= 0.4.0 && < 0.8,
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.6,


### PR DESCRIPTION
The first alpha of `ghc-9.12` has just been released.

Can be fixed on Hackage with a metadata edit.