### PR TITLE
Fix #96 Write files with utf8 encoding, not, effectively, char8

### DIFF
--- a/src/Common.hs
+++ b/src/Common.hs
@@ -30,8 +30,10 @@ default_compiler = "cc"
 ------------------------------------------------------------------------
 -- Write the output files.
 
-writeBinaryFile :: FilePath -> String -> IO ()
-writeBinaryFile fp str = withBinaryFile fp WriteMode $ \h -> hPutStr h str
+writeUtf8File :: FilePath -> String -> IO ()
+writeUtf8File fp str = withBinaryFile fp WriteMode $ \h -> do
+  hSetEncoding h utf8
+  hPutStr h str
 
 rawSystemL :: FilePath -> FilePath -> String -> Bool -> FilePath -> [String] -> IO ()
 rawSystemL outDir outBase action flg prog args = withResponseFile outDir outBase args $ \rspFile -> do

--- a/src/CrossCodegen.hs
+++ b/src/CrossCodegen.hs
@@ -275,7 +275,7 @@ checkValidity input = do
                concatMap (uncurry (outValidityCheck (cViaAsm config))) (zip input [0..])
     testLog ("checking for compilation errors") $ do
         success <- makeTest2 (".c",".o") $ \(cFile,oFile) -> do
-            liftTestIO $ writeBinaryFile cFile test
+            liftTestIO $ writeUtf8File cFile test
             compiler <- testGetCompiler
             runCompiler compiler
                         (["-S" | cViaAsm config ]++
@@ -619,7 +619,7 @@ runCompileAsmIntegerTest _ = error "runCompileAsmIntegerTestargument isn't a Spe
 runCompileExtract :: String -> String -> TestMonad Integer
 runCompileExtract k testStr = do
     makeTest3 (".c", ".s", ".txt") $ \(cFile, sFile, stdout) -> do
-      liftTestIO $ writeBinaryFile cFile testStr
+      liftTestIO $ writeUtf8File cFile testStr
       flags <- testGetFlags
       compiler <- testGetCompiler
       _ <- runCompiler compiler
@@ -631,7 +631,7 @@ runCompileExtract k testStr = do
 runCompileTest :: String -> TestMonad Bool
 runCompileTest testStr = do
     makeTest3 (".c", ".o",".txt") $ \(cFile,oFile,stdout) -> do
-      liftTestIO $ writeBinaryFile cFile testStr
+      liftTestIO $ writeUtf8File cFile testStr
       flags <- testGetFlags
       compiler <- testGetCompiler
       runCompiler compiler

--- a/src/DirectCodegen.hs
+++ b/src/DirectCodegen.hs
@@ -66,7 +66,7 @@ outputDirect config outName outDir outBase name toks = do
                                     "if","ifdef","ifndef", "elif","else","endif"]) $
              die (file ++ ":" ++ show line ++ " directive \"" ++ key ++ "\" is not safe for cross-compilation"))
 
-    writeBinaryFile cProgName $
+    writeUtf8File cProgName $
         outTemplateHeaderCProg (cTemplate config)++
         concatMap outFlagHeaderCProg flags++
         concatMap outHeaderCProg specials++
@@ -99,7 +99,7 @@ outputDirect config outName outDir outBase name toks = do
         rawSystemWithStdOutL outDir outBase ("running " ++ execProgName) beVerbose execProgName [] outName
         possiblyRemove progName $ do
 
-          when needsH $ writeBinaryFile outHName $
+          when needsH $ writeUtf8File outHName $
             "#ifndef "++includeGuard++"\n" ++
             "#define "++includeGuard++"\n" ++
             "#include <HsFFI.h>\n" ++
@@ -111,7 +111,7 @@ outputDirect config outName outDir outBase name toks = do
             concatMap outTokenH specials++
             "#endif\n"
 
-          when needsC $ writeBinaryFile outCName $
+          when needsC $ writeUtf8File outCName $
             "#include \""++outHFile++"\"\n"++
             concatMap outTokenC specials
             -- NB. outHFile not outHName; works better when processed

--- a/src/UtilsCodegen.hs
+++ b/src/UtilsCodegen.hs
@@ -27,7 +27,7 @@ withUtilsObject config outDir outBase f = do
         oUtilsName = outDir ++ outBase ++ "_hsc_utils.o"
 
     possiblyRemove cUtilsName $ do
-        writeBinaryFile cUtilsName $ unlines $
+        writeUtf8File cUtilsName $ unlines $
              -- These header will cause a mismatch with any mingw-w64 header by
              -- including system headers before user headers in the hsc file.
              -- We *MUST* include user headers *BEFORE* automatic ones.  */


### PR DESCRIPTION
Based on my experiments on Windows, issue:
* #96 

can be fixed by writing files with UTF8 encoding, instead of, effectively, `char8`.