### PR TITLE
Fix Windows build with clang: replace swprintf_s with portable alternative

### DIFF
--- a/cbits/utils.c
+++ b/cbits/utils.c
@@ -46,11 +46,21 @@ bool __get_temp_file_name (wchar_t* pathName, wchar_t* prefix,
         {
           wchar_t* temp = _wcsdup (tempFileName);
           if (wcsnlen(drive, _MAX_DRIVE) == 0)
-            swprintf_s(tempFileName, MAX_PATH, L"%s\%s%s",
+#ifdef __clang__
+            swprintf(tempFileName, MAX_PATH, L"%s\\%s%s",
                       dir, fname, suffix);
+#else
+            swprintf_s(tempFileName, MAX_PATH, L"%s\\%s%s",
+                      dir, fname, suffix);
+#endif
           else
-            swprintf_s(tempFileName, MAX_PATH, L"%s\%s\%s%s",
+#ifdef __clang__
+            swprintf(tempFileName, MAX_PATH, L"%s\\%s\\%s%s",
                       drive, dir, fname, suffix);
+#else
+            swprintf_s(tempFileName, MAX_PATH, L"%s\\%s\\%s%s",
+                      drive, dir, fname, suffix);
+#endif
           success
              = MoveFileExW(temp, tempFileName, MOVEFILE_WRITE_THROUGH
                                                | MOVEFILE_COPY_ALLOWED) != 0;


### PR DESCRIPTION
Use conditional compilation to call swprintf() when building with clang instead of swprintf_s(), which depends on the Microsoft-specific __local_stdio_printf_options symbol that's not available with LLVM's linker.

This resolves the linker error:
ld.lld: error: undefined symbol: __local_stdio_printf_options

The change maintains compatibility with both MSVC (using swprintf_s) and clang (using standard swprintf) while preserving the same functionality.

resolves https://github.com/haskell/hsc2hs/issues/101