### PR TITLE
Bump base upper bound to <4.23

### DIFF
--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -77,7 +77,7 @@ Executable hsc2hs
 
     Other-Extensions: CPP, NoMonomorphismRestriction
 
-    Build-Depends: base       >= 4.3.0 && < 4.22,
+    Build-Depends: base       >= 4.3.0 && < 4.23,
                    containers >= 0.4.0 && < 0.9,
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.6,


### PR DESCRIPTION
Allowing GHC 9.14.