### PR TITLE
Support GHC 9.14; remove support for GHC 8.0 and below

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,8 +16,9 @@ jobs:
         ghc: ['9.10', '9.12', '9.14']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
-          - os: ubuntu-latest
-            ghc: '8.0'
+          # Fails with GHC 8.0
+          # - os: ubuntu-latest
+          #   ghc: '8.0'
           - os: ubuntu-latest
             ghc: '8.2'
           - os: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         ghc: ['9.10', '9.12', '9.14']
         os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -49,4 +50,5 @@ jobs:
       - run: cabal check
       - run: cabal update
       - run: cabal build
+      - run: cabal build --enable-tests
       - run: cabal test --test-show-details=direct --verbose

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,20 +12,40 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ['9.2.3', '9.4.5', '9.6.6', '9.8.4', '9.10.1']
-        cabal: ['3.14.1.1']
+        ghc: ['9.10', '9.12', '9.14']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        exclude:
-          - os: macOS-latest
-            ghc: '9.2.3'
+        include:
+          - os: ubuntu-latest
+            ghc: '8.0'
+          - os: ubuntu-latest
+            ghc: '8.2'
+          - os: ubuntu-latest
+            ghc: '8.4'
+          - os: ubuntu-latest
+            ghc: '8.6'
+          - os: ubuntu-latest
+            ghc: '8.8'
+          - os: ubuntu-latest
+            ghc: '8.10'
+          - os: ubuntu-latest
+            ghc: '9.0'
+          - os: ubuntu-latest
+            ghc: '9.2'
+          - os: ubuntu-latest
+            ghc: '9.4'
+          - os: ubuntu-latest
+            ghc: '9.6'
+          - os: ubuntu-latest
+            ghc: '9.8'
     name: "${{ matrix.os }} - ${{ matrix.ghc }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Haskell
         uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
+          cabal-version: latest
+          cabal-update: false
       - run: cabal check
       - run: cabal update
       - run: cabal build

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+ - Remove support for GHC 8.0 and below.
+
+
 ## 0.68.10
 
  - Further improve robustness of detection of pointer types in `--cross` mode.

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -40,7 +40,6 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.4.4
   GHC == 8.2.2
-  GHC == 8.0.2
 
 extra-source-files:
   changelog.md

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -1,7 +1,7 @@
 cabal-version: >=1.10
 Name: hsc2hs
 Version: 0.68.10
-x-revision: 3
+x-revision: 5
 
 Copyright: 2000, Marcin Kowalczyk
 License: BSD3
@@ -28,10 +28,11 @@ Data-Files: template-hsc.h
 build-type: Simple
 
 tested-with:
-  GHC == 9.12.1
-  GHC == 9.10.1
-  GHC == 9.8.2
-  GHC == 9.6.6
+  GHC == 9.14.1
+  GHC == 9.12.2
+  GHC == 9.10.3
+  GHC == 9.8.4
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -98,7 +99,7 @@ test-suite spec
   other-modules:     ATTParser Flags BDD
   ghc-options:       -Wall -threaded
   type:              exitcode-stdio-1.0
-  build-depends:     base                 >= 4.3.0   && < 4.22,
+  build-depends:     base                 >= 4.3.0   && < 4.23,
                      tasty                >= 1.5     && < 1.6,
                      tasty-hunit          >= 0.10    && < 0.11
 

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -1,4 +1,4 @@
-cabal-version: >=1.10
+cabal-version: 2.0
 Name: hsc2hs
 Version: 0.68.10
 
@@ -41,8 +41,10 @@ tested-with:
   GHC == 8.4.4
   GHC == 8.2.2
 
-extra-source-files:
+extra-doc-files:
   changelog.md
+
+extra-source-files:
   test/asm/*.s
 
 flag in-ghc-tree
@@ -70,17 +72,19 @@ Executable hsc2hs
         Compat.ResponseFile
         Compat.TempFile
         Paths_hsc2hs
+    autogen-modules:
+        Paths_hsc2hs
 
     c-sources:
         cbits/utils.c
 
     Other-Extensions: CPP, NoMonomorphismRestriction
 
-    Build-Depends: base       >= 4.3.0 && < 4.23,
+    Build-Depends: base       >= 4.10  && < 4.23,
                    containers >= 0.4.0 && < 0.9,
                    directory  >= 1.1.0 && < 1.4,
                    filepath   >= 1.2.0 && < 1.6,
-                   process    >= 1.1.0 && < 1.7
+                   process    >= 1.6   && < 1.7
 
     if os(windows)
       -- N.B. Job object support was irreparably broken prior to 1.6.8.
@@ -94,10 +98,13 @@ Executable hsc2hs
 test-suite spec
   main-is:           Spec.hs
   hs-source-dirs:    src/ test/
-  other-modules:     ATTParser Flags BDD
+  other-modules:
+    ATTParser
+    BDD
+    Flags
   ghc-options:       -Wall -threaded
   type:              exitcode-stdio-1.0
-  build-depends:     base                 >= 4.3.0   && < 4.23,
+  build-depends:     base                 >= 4.10    && < 4.23,
                      tasty                >= 1.5     && < 1.6,
                      tasty-hunit          >= 0.10    && < 0.11
 

--- a/hsc2hs.cabal
+++ b/hsc2hs.cabal
@@ -1,7 +1,6 @@
 cabal-version: >=1.10
 Name: hsc2hs
 Version: 0.68.10
-x-revision: 5
 
 Copyright: 2000, Marcin Kowalczyk
 License: BSD3

--- a/src/Common.hs
+++ b/src/Common.hs
@@ -1,11 +1,7 @@
 {-# LANGUAGE CPP #-}
 module Common where
 
-#if MIN_VERSION_base(4,6,0)
 import Prelude hiding ( Foldable(..) )
-#else
-import Data.List ( foldl' )
-#endif
 import qualified Control.Exception as Exception
 import qualified Compat.TempFile as Compat
 import Control.Monad            ( when )
@@ -44,9 +40,7 @@ rawSystemL outDir outBase action flg prog args = withResponseFile outDir outBase
   -- between the last child dieing and not holding a lock on the response file
   -- and the response file getting deleted.
     { std_err = CreatePipe
-#if MIN_VERSION_process(1,5,0)
     , use_process_jobs = True
-#endif
     }
   errdata <- maybeReadHandle progerr
   exitStatus <- waitForProcess ph
@@ -72,9 +66,7 @@ rawSystemWithStdOutL outDir outBase action flg prog args outFile = withResponseF
     createProcess
       (proc prog  ['@':rspFile])
          { std_out = UseHandle hOut, std_err = CreatePipe
-#if MIN_VERSION_process(1,5,0)
          , use_process_jobs = True
-#endif
          }
   errdata <- maybeReadHandle progerr
   exitStatus <- waitForProcess process

--- a/src/Compat/TempFile.hs
+++ b/src/Compat/TempFile.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#endif
 
 -- This module backports `openTempFile` from GHC 8.10 to hsc2hs in order to get
 -- an atomic `openTempFile` implementation on Windows when using older GHC

--- a/src/DirectCodegen.hs
+++ b/src/DirectCodegen.hs
@@ -6,11 +6,7 @@ The standard mode for hsc2hs: generates a C file which is
 compiled and run; the output of that program is the .hs file.
 -}
 
-#if MIN_VERSION_base(4,6,0)
 import Prelude hiding ( Foldable(..) )
-#else
-import Data.List ( foldl' )
-#endif
 import Data.Char                ( isAlphaNum, toUpper )
 import Data.Foldable            ( Foldable(..) )
 import Control.Monad            ( when, forM_ )

--- a/test/BDD.hs
+++ b/test/BDD.hs
@@ -7,16 +7,7 @@ import Control.Monad (ap)
 import Test.Tasty
 import Test.Tasty.HUnit
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Applicative (..))
-#endif
-
-#if MIN_VERSION_base(4,9,0)
 import GHC.Stack (HasCallStack)
-#define HASCALLSTACK , HasCallStack
-#else
-#define HASCALLSTACK
-#endif
 
 -------------------------------------------------------------------------------
 -- HSpec like DSL for test-framework
@@ -63,5 +54,5 @@ describe n t =  do
 it :: TestName -> Assertion -> TestM ()
 it n assertion = tell1 $ testCase n assertion
 
-shouldBe :: (Eq a, Show a HASCALLSTACK) => a -> a -> Assertion
+shouldBe :: (Eq a, Show a, HasCallStack) => a -> a -> Assertion
 shouldBe = (@?=)

--- a/test/BDD.hs
+++ b/test/BDD.hs
@@ -7,8 +7,6 @@ import Control.Monad (ap)
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import GHC.Stack (HasCallStack)
-
 -------------------------------------------------------------------------------
 -- HSpec like DSL for test-framework
 -------------------------------------------------------------------------------
@@ -24,12 +22,10 @@ tell1 :: TestTree -> TestM ()
 tell1 t = TestM $ \ts -> return (t : ts, ())
 
 instance Applicative TestM where
-    pure = return
+    pure x = TestM $ \xs -> return (xs, x)
     (<*>) = ap
 
 instance Monad TestM where
-    return x = TestM $ \xs -> return (xs, x)
-
     m >>= k = TestM $ \xs -> do
         (ys, x) <- unTestM m xs
         unTestM (k x) ys


### PR DESCRIPTION
- bump `base` for GHC 9.14
- extend test range to GHC 8.2 - 9.14
- bump `cabal-version` to 2.0
- drop support for GHC 8.0 and below; remove respective conditionals

Closes #105.